### PR TITLE
Possibility to scan all files.

### DIFF
--- a/tasks/console-log-test.js
+++ b/tasks/console-log-test.js
@@ -6,6 +6,7 @@ var checkFile = require('./lib/check-file');
 module.exports = function (grunt) {
   grunt.registerMultiTask('console-log-test', 'Check for console.log statements', function () {
     var done = this.async();
+    var stop = !grunt.cli.options.all && true;
 
     grunt.util.async.forEach(this.filesSrc, function _checkFiles(file, next) {
       var fileContents, errs;
@@ -19,7 +20,7 @@ module.exports = function (grunt) {
           grunt.log.errorlns(file + ' has console.log statement at line ' + err);
         });
 
-        next();
+        next(stop);
       }
 
       next();

--- a/tasks/console-log-test.js
+++ b/tasks/console-log-test.js
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
           grunt.log.errorlns(file + ' has console.log statement at line ' + err);
         });
 
-        next(true);
+        next();
       }
 
       next();


### PR DESCRIPTION
Hi, we need in our project to scan all files and show console.log mentions for all of them. 
Currently when console.log is found grunt stops searching in all other files. 

I've added cli option that doesn't brake anything backwards. If --all flag is specified when running task, all files will be scanned, if there is no --all flag everything should works as before. 

If you want I can update Readme.
