### PR TITLE
Added possibility to scan multiple files

### DIFF
--- a/tasks/console-log-test.js
+++ b/tasks/console-log-test.js
@@ -6,6 +6,8 @@ var checkFile = require('./lib/check-file');
 module.exports = function (grunt) {
   grunt.registerMultiTask('console-log-test', 'Check for console.log statements', function () {
     var done = this.async();
+    var all = grunt.cli.options.all || false;
+    var hasErrors = false;
 
     grunt.util.async.forEach(this.filesSrc, function _checkFiles(file, next) {
       var fileContents, errs;
@@ -18,16 +20,20 @@ module.exports = function (grunt) {
         errs.forEach(function addErrorToList(err) {
           grunt.log.errorlns(file + ' has console.log statement at line ' + err);
         });
-
+        hasErrors = true;
         next(true);
       }
 
       next();
     }, function handleResults(failureStatus) {
-        if (!failureStatus) return done();
+        if (all || !failureStatus) return done();
 
         grunt.warn('console.log check failed.');
       done();
     });
+    if(hasErrors){
+      grunt.warn('console.log check failed.');
+      done();
+    }
   });
 };


### PR DESCRIPTION
I'll just repeat message from last PR :)

Hi, we need in our project to scan all files and show console.log mentions for all of them. 
Currently when console.log is found grunt stops searching in all other files.

I've added cli option that doesn't break anything backwards. If --all flag is specified when running task, all files will be scanned, if there is no --all flag everything should works as before.

If you want I can update Readme.
